### PR TITLE
Fix accessing a typed property before it is initialized

### DIFF
--- a/src/Bref/ConnectionTracker.php
+++ b/src/Bref/ConnectionTracker.php
@@ -26,8 +26,10 @@ abstract class ConnectionTracker
 
     public static function closeAll(): void
     {
-        foreach (self::$connections as $connection => $_) {
-            $connection->close();
+        if (isset(self::$connections)) {
+            foreach (self::$connections as $connection => $_) {
+                $connection->close();
+            }
         }
 
         // @phpstan-ignore-next-line


### PR DESCRIPTION
The typed property $connections is accessed before it is initialized.
```
Typed static Typed SQLiteS3\\Bref\\ConnectionTracker::$connections must not be accessed before initialization
```